### PR TITLE
docs(AGENTS.md): update to reflect current stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,21 +2,27 @@
 
 ## Project Overview
 
-Bun + Turborepo monorepo for the Skatekrak skateboarding platform. Three apps and two shared packages.
+Bun + Turborepo monorepo for the Skatekrak skateboarding platform. Three apps and six shared packages.
 
-| Package           | Path             | Tech                                                        | Deploys To              |
-| ----------------- | ---------------- | ----------------------------------------------------------- | ----------------------- |
-| `@krak/web`       | `apps/web`       | Next.js 14 (Pages Router), React 18, Zustand, Redux Toolkit | Vercel                  |
-| `@krak/api`       | `apps/api`       | Elysia (Bun), oRPC, MongoDB, PostgreSQL                     | Dokploy (custom server) |
-| `@krak/carrelage` | `apps/carrelage` | Express, Mongoose, MongoDB                                  | Not deployed            |
-| `@krak/trpc`      | `packages/trpc`  | tRPC router (spots, maps)                                   | —                       |
-| `@krak/types`     | `packages/types` | Shared TypeScript types                                     | —                       |
+| Package            | Path               | Tech                                                          | Deploys To              |
+| ------------------ | ------------------ | ------------------------------------------------------------- | ----------------------- |
+| `@krak/web`        | `apps/web`         | Next.js 16 (Pages Router), React 19, Zustand, Redux Toolkit   | Vercel                  |
+| `@krak/api`        | `apps/api`         | Elysia (Bun), oRPC, PostgreSQL (Prisma 7), BetterAuth         | Dokploy (custom server) |
+| `@krak/manager`    | `apps/manager`     | Next.js 16 (App Router), React 19, oRPC                       | Dokploy                 |
+| `@krak/auth`       | `packages/auth`    | BetterAuth 1.2 wrapper                                        | —                       |
+| `@krak/contracts`  | `packages/contracts` | oRPC contract definitions (Zod schemas)                     | —                       |
+| `@krak/prisma`     | `packages/prisma`  | Prisma 7 client + PostgreSQL schema                           | —                       |
+| `@krak/ui`         | `packages/ui`      | Shared React components (Radix UI + Tailwind CSS 4)           | —                       |
+| `@krak/types`      | `packages/types`   | Shared TypeScript types                                       | —                       |
+| `@krak/utils`      | `packages/utils`   | Shared utility functions                                      | —                       |
 
-Dependency chain: `web` -> `trpc` -> `types`; `api` -> `trpc` -> `types`.
+Dependency chain: `web` → `contracts` → `types`; `api` → `contracts` → `prisma` → `auth`; `manager` → `contracts` → `ui`.
+
+> `packages/trpc` is an empty package left over from the MongoDB-era architecture — it contains no implementation and is unused.
 
 ## Build / Lint / Test Commands
 
-Package manager is **Bun** (`bun@1.3.9`). Node engine: 24. Always use `bun` instead of npm/yarn/pnpm.
+Package manager is **Bun** (`bun@1.3.10`). Node engine: 24. Always use `bun` instead of npm/yarn/pnpm.
 
 ```bash
 # Install dependencies
@@ -24,43 +30,43 @@ bun install
 
 # Full monorepo
 bun run build          # turbo build (all apps/packages)
-bun run lint           # turbo lint + manypkg check
-bun run dev            # turbo dev --parallel (all apps)
+bun run lint           # oxlint . && bunx sherif
+bun run lint:fix       # oxlint . --fix && bunx sherif --fix
+bun run format         # oxfmt .
+bun run format:check   # oxfmt --check .
+bun run dev            # turbo dev --parallel --ui tui (all apps)
 
 # Individual apps
 bun run dev:web        # Next.js dev server (port 3000)
-bun run dev:api        # Elysia dev with --watch (port 3000)
-bun run dev:carrelage  # tsc-watch + restart (port 3636)
+bun run dev:api        # Elysia dev with --watch (port 3001)
+bun run dev:manager    # Next.js manager dev server (port 3002)
 
 # Build individual apps
+bun run build:web      # turbo build --filter=@krak/web
 bun run build:api      # turbo build --filter=@krak/api
-bun run build:carrelage # turbo build --filter=@krak/carrelage
+bun run build:manager  # turbo build --filter=@krak/manager
+bun run start:api      # cd apps/api && bun run start
 
-# Lint individual apps
-cd apps/web && bun run lint            # ESLint (no autofix)
-cd apps/web && bun run style           # ESLint with --fix
-cd apps/carrelage && bun run lint      # ESLint with --fix
-
-# Tests (carrelage only — no tests in web or api)
-cd apps/carrelage && bun run build     # Must compile TS first
-cd apps/carrelage && bun run test:cmd:dev   # Mocha + nyc (needs running MongoDB)
-cd apps/carrelage && bun run test:cmd:ci    # CI mode with 60s timeout
+# Prisma (run inside packages/prisma)
+cd packages/prisma && bun run db:migrate   # prisma migrate dev
+cd packages/prisma && bun run db:generate  # prisma generate
+cd packages/prisma && bun run db:studio    # prisma studio
 ```
 
-There is no single-test runner configured. Carrelage tests use Mocha on the compiled `dist/tests/tests.js` bundle — there is no way to run a single test file without modifying the test entry point.
+There are no unit or integration tests configured in the monorepo. Verification is done via TypeScript compilation and linting.
 
-## Formatting (Prettier)
+## Formatting
 
-Configured in root `.prettierrc`, applies to all packages:
+Configured with **oxfmt** at the repo root. Run `bun run format` to auto-format, `bun run format:check` in CI.
 
-- **Indentation**: 4 spaces
-- **Quotes**: Single quotes (`'`)
-- **Print width**: 120 characters
-- **Trailing commas**: Always (`all`)
-- **Arrow parens**: Always (`(x) => ...`)
-- **Bracket spacing**: Yes (`{ foo }`)
+Standard settings (see `.prettierrc` still present but oxfmt is the active tool):
 
-VSCode is configured to format on save and auto-fix ESLint issues (`.vscode/settings.json`).
+- 4 spaces indentation
+- Single quotes
+- 120-character print width
+- Trailing commas
+
+VSCode is configured to format on save (`.vscode/settings.json`).
 
 ## Code Style Guidelines
 
@@ -69,14 +75,15 @@ VSCode is configured to format on save and auto-fix ESLint issues (`.vscode/sett
 Order imports as: external packages, then internal workspace packages (`@krak/*`), then relative imports. Separate groups with a blank line.
 
 ```ts
-import { ObjectId } from 'mongodb';
 import { z } from 'zod';
 
 import { type Spot, Status } from '@krak/types';
-import { publicProcedure, router } from '../trpc';
+import { contract } from '@krak/contracts';
+
+import { mapStore } from '../store/map';
 ```
 
-Use `import type { ... }` for type-only imports. This is enforced by TypeScript's `isolatedModules`.
+Use `import type { ... }` for type-only imports. Enforced by TypeScript's `isolatedModules`.
 
 ### Naming Conventions
 
@@ -89,65 +96,101 @@ Use `import type { ... }` for type-only imports. This is enforced by TypeScript'
 
 ### TypeScript
 
-- Strict mode is ON in all packages. `noImplicitAny` is OFF in `apps/web` but ON in `apps/carrelage`.
+- Strict mode is ON in all packages.
 - Prefer `type` over `interface` for unions, intersections, and utility types. Use either for object shapes.
-- `@typescript-eslint/no-explicit-any` is set to **warn** (not error). Avoid `any` but it won't block builds.
-- Path alias: `@/*` maps to `./src/*` in `apps/web` (e.g., `import Foo from '@/components/Foo'`).
-- `apps/api` and `packages/trpc` extend `@total-typescript/tsconfig` presets.
+- Path alias: `@/*` maps to `./src/*` in `apps/web` and `apps/manager`.
+- `apps/api` and all shared packages extend `@total-typescript/tsconfig` presets.
+- Environment variables are validated at startup with `@t3-oss/env-core` + Zod (`apps/api/src/env.ts`, `apps/web/src/lib/env.ts`).
 
-### React (apps/web)
+### React (apps/web and apps/manager)
 
 - Functional components only. Type with `React.FC<Props>` or inline props.
-- `react/react-in-jsx-scope` is OFF (React 17+ JSX transform).
-- State management: **Zustand** for map-related state, **Redux Toolkit** for mag/news/videos.
-- Styled-components are imported as `import * as S from './Component.styled'`.
-- Data fetching: **oRPC + React Query** for spot/map data.
-- Form validation: **Formik + Yup** for forms, **Zod** for tRPC input schemas.
+- `react/react-in-jsx-scope` is OFF (React 19 JSX transform).
+- `apps/web` — State: **Zustand** for map-related state, **Redux Toolkit** for mag/news/videos.
+- `apps/manager` — State: local React state + React Query only.
+- Styled-components (apps/web) are imported as `import * as S from './Component.styled'`.
+- Data fetching: **oRPC + React Query** for all spot/map/admin data.
+- Form validation: **Formik + Yup** in `apps/web`; **react-hook-form + Zod** in `apps/manager`.
 - URL state: **nuqs** for query string state management.
 
-### tRPC (packages/trpc)
+### API (apps/api — Elysia + oRPC)
 
-- Input validation with **Zod** schemas.
-- Context provides `db` (MongoDB native client) — no Mongoose in the tRPC package.
-- Procedures are grouped into routers (`spotsRouter`, `mapsRouter`) and merged into `appRouter`.
+- Routes are defined as **oRPC procedures** on `@krak/contracts` and implemented in `apps/api`.
+- All input/output shapes are defined with **Zod** in `packages/contracts`.
+- Auth is handled by **BetterAuth** (`packages/auth`), not custom middleware.
+- Database access goes through **Prisma** (`packages/prisma`) — no raw SQL or Mongoose.
+- File uploads: use the S3/imgproxy pipeline (configured in env). Do not use Cloudinary for new code.
+- CORS allows `(\w+\.)?skatekrak\.com$` origins; configured in Elysia via `@elysiajs/cors`.
+- Cron jobs use `@elysiajs/cron` (example: weekly stats every Monday 8am).
 
-### Carrelage (apps/carrelage)
+### Database (packages/prisma)
 
-- Legacy Express REST API with Mongoose ODM.
-- Uses **Joi** for request validation, **Bunyan** for structured logging.
-- Error monitoring via **Bugsnag**.
-- Stricter TS: `noImplicitAny`, `noUnusedLocals`, `noUnusedParameters` all enabled.
+- PostgreSQL 17 is the sole database. All entities are in the Prisma schema.
+- Run migrations with `prisma migrate dev` from `packages/prisma`.
+- The MongoDB driver dependency in `packages/prisma` exists only for the one-time migration scripts (`migrate-from-mongo.ts`, `migrate-maps.ts`) — do not use it for new features.
+
+### Auth (packages/auth)
+
+- **BetterAuth 1.2** wraps session and OAuth logic.
+- Import the client from `@krak/auth/client` in frontend apps.
+- Import the server instance from `@krak/auth` in `apps/api`.
+
+### Shared UI (packages/ui)
+
+- Built with **Radix UI** (headless primitives) + **Tailwind CSS 4**.
+- Built via `tsdown`. Run `bun run build` inside the package to rebuild after changes.
+- Import components as `import { Button } from '@krak/ui'`.
 
 ### Error Handling
 
-- No centralized error handling utility. Use `try/catch` with `console.error()` in most cases.
-- `apps/carrelage` uses Bugsnag for error tracking and Express error middleware.
-- `apps/api` uses Elysia's built-in error handling.
-- Environment variables are validated at startup with `@t3-oss/env-core` + Zod (`apps/api/src/env.ts`).
+- Use `try/catch` with `console.error()` for unexpected errors.
+- `apps/api` uses Elysia's built-in error handling and `@bogeychan/elysia-logger`.
+- Environment variable validation failures throw at startup, not at runtime.
 
 ## Infrastructure
 
-- **Docker Compose** for local dev: `web`, `api`, `carrelage`, `mongodb` services.
-- Traefik reverse proxy routes: `dev.skatekrak.com` (web), `api.dev.skatekrak.com` (api), `carrelage.dev.skatekrak.com` (carrelage).
-- MongoDB 7.0 on port 27017.
-- CI: GitHub Actions — `bun install --frozen-lockfile && bun lint` on push to main, Vercel preview on PRs.
+- **Docker Compose** for local dev: `api`, `postgres`, `meilisearch` services.
+  - PostgreSQL 17 on port 5433 (credentials: `krak`/`krak`, db: `krak`)
+  - Meilisearch v1.13 on port 7700
+- No Traefik reverse proxy in local dev — apps run directly on their respective ports.
+- CI: GitHub Actions — `bun install --frozen-lockfile`, `oxlint`, `sherif`, `oxfmt --check`, `turbo build` on push to main.
+- Deployments: Vercel (web), Dokploy (api, manager).
 
-## Key Directories (apps/web)
+## Key Directories
 
+### apps/web
 ```
 src/
   components/   — React components (PascalCase dirs with index.ts barrel exports)
   pages/        — Next.js Pages Router (file-based routing)
   store/        — Zustand + Redux stores
   lib/          — Utilities, hooks, helpers
-  server/       — Server-side utilities (tRPC)
+  server/       — Server-side utilities
   styles/       — Global styles (Tailwind + Stylus)
+```
+
+### apps/api
+```
+src/
+  routers/      — oRPC procedure implementations
+  lib/          — Auth, Prisma, Meilisearch, S3 clients
+  env.ts        — Env validation (@t3-oss/env-core)
+  index.ts      — Elysia app entry point
+```
+
+### apps/manager
+```
+src/
+  app/          — Next.js App Router pages
+  components/   — Admin UI components
+  lib/          — oRPC client, auth hooks
 ```
 
 ## Common Pitfalls
 
-- `apps/web` uses **Next.js Pages Router** (not App Router). Routes are in `src/pages/`.
-- The web app compiles Stylus CSS before the Next.js build (`build:style` script). Don't forget this step.
-- Workspace packages (`@krak/trpc`, `@krak/types`) are transpiled by Next.js via `transpilePackages` in `next.config.js`.
-- The preview CI workflow still uses pnpm/Node 18 (legacy), but the main deploy uses Bun. Always use Bun locally.
-- `apps/carrelage` tests require a running MongoDB instance and compiled TypeScript (`bun run build` first).
+- `apps/web` uses **Pages Router** (not App Router). Routes are in `src/pages/`. `apps/manager` uses App Router.
+- The web app compiles Stylus CSS before the Next.js build (`build:style` script). This runs automatically via the Turborepo pipeline but watch for it on manual builds.
+- Workspace packages (`@krak/contracts`, `@krak/types`, `@krak/ui`) are transpiled by Next.js via `transpilePackages` in `next.config.js`.
+- The Prisma client must be generated (`prisma generate`) before the API can build. This happens automatically in the Turborepo pipeline.
+- Always target the **PostgreSQL** database — there is no MongoDB in local dev or production anymore.
+- `packages/trpc` is an empty dead package. Do not import from it or add code to it.


### PR DESCRIPTION
## Summary

- Remove stale `apps/carrelage` (Express/Mongoose/MongoDB) — app no longer exists
- Update `apps/web`: Next.js 14 → 16.1.6, React 18 → 19
- Add `apps/manager` (Next.js 16 App Router, port 3002)
- Replace MongoDB/tRPC references with PostgreSQL/Prisma 7/oRPC
- Add all 6 current shared packages (`@krak/auth`, `@krak/contracts`, `@krak/prisma`, `@krak/ui`, `@krak/types`, `@krak/utils`)
- Replace ESLint/Prettier toolchain docs with oxlint/oxfmt
- Update Docker Compose section: PostgreSQL 17 + Meilisearch only
- Add dedicated sections for Auth (BetterAuth), Database (Prisma/PostgreSQL), and shared UI
- Update CI section to reflect oxlint/sherif/oxfmt pipeline
- Note `packages/trpc` as empty/dead — do not use

## Test plan

- [ ] Commands in AGENTS.md verified against root `package.json` scripts
- [ ] Package table verified against workspace `package.json` files
- [ ] Docker Compose section matches `docker-compose.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)